### PR TITLE
allow php 5.3 due rc 1.1.X allow also, dont use inline array declaration from php 5.4

### DIFF
--- a/image_paster.php
+++ b/image_paster.php
@@ -20,9 +20,9 @@ class image_paster extends rcube_plugin
 
   function init()
   {
-    $this->add_hook('html_editor', [$this, 'html_editor']);
-    $this->add_hook('render_page', [$this, 'compose']);
-    $this->register_action('plugin.uploadClipboardImage', [$this, 'handleUpload']);
+    $this->add_hook('html_editor', array($this, 'html_editor'));
+    $this->add_hook('render_page', array($this, 'compose'));
+    $this->register_action('plugin.uploadClipboardImage', array($this, 'handleUpload'));
   }
 
   /**


### PR DESCRIPTION
this make able to use the plugin in already made instalation of RC 1.1.X series LTS
due that version already supports php 5.3 as minimun